### PR TITLE
feat: add withSpan helper

### DIFF
--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -15,7 +15,7 @@
  */
 
 import { Context } from './types';
-import { Baggage, Span, SpanContext } from '../';
+import { Baggage, Span, SpanContext, context } from '../';
 import { NoopSpan } from '../trace/NoopSpan';
 
 /**
@@ -53,6 +53,28 @@ export function getSpan(context: Context): Span | undefined {
  */
 export function setSpan(context: Context, span: Span): Context {
   return context.setValue(SPAN_KEY, span);
+}
+
+/**
+ * Helper to execute the given function on a new context created from
+ * active context with given span set.
+ * Note: The global context manager is used to get active context.
+ * @param span span to set on context
+ * @param fn function to execute in new context
+ * @param thisArg optional receiver to be used for calling fn
+ * @param args optional arguments forwarded to fn
+ */
+export function withSpan<
+  A extends unknown[],
+  F extends (...args: A) => ReturnType<F>
+>(
+  span: Span,
+  fn: F,
+  thisArg?: ThisParameterType<F>,
+  ...args: A
+): ReturnType<F> {
+  const ctx = setSpan(context.active(), span);
+  return context.with(ctx, fn, thisArg, ...args);
 }
 
 /**

--- a/test/api/global.test.ts
+++ b/test/api/global.test.ts
@@ -44,6 +44,12 @@ describe('Global Utils', () => {
     api1.trace.disable();
   });
 
+  afterEach(() => {
+    api1.context.disable();
+    api1.propagation.disable();
+    api1.trace.disable();
+  });
+
   it('should change the global context manager', () => {
     const original = api1.context['_getContextManager']();
     const newContextManager = new NoopContextManager();


### PR DESCRIPTION
Add `withSpan` helper to execute a function on a context holding a given span.

fixes: https://github.com/open-telemetry/opentelemetry-js/issues/1923

I put the new API next to the existing helpers `setSpan`, `getSpan`,... as it seem to me the best match currently.
https://github.com/open-telemetry/opentelemetry-js/issues/1750 discusses to use more namespacing but as of now this seems the best place form user point of view.

In https://github.com/open-telemetry/opentelemetry-js/issues/1923 there were several proposals where to place it. I'm fine with moving it if consensus is on `api.trace` or `api.context` or ...

