### PR TITLE
feat: add tracer.startActiveSpan() helper

### DIFF
--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -15,7 +15,7 @@
  */
 
 import { Context } from './types';
-import { Baggage, Span, SpanContext } from '../';
+import { Baggage, Span, SpanContext, context } from '../';
 import { NoopSpan } from '../trace/NoopSpan';
 
 /**
@@ -53,6 +53,28 @@ export function getSpan(context: Context): Span | undefined {
  */
 export function setSpan(context: Context, span: Span): Context {
   return context.setValue(SPAN_KEY, span);
+}
+
+/**
+ * Helper to execute the given function on a new context created from
+ * active context with given span set.
+ * Note: The global context manager is used to get active context.
+ * @param span span to set on context
+ * @param fn function to execute in new context
+ * @param thisArg optional receiver to be used for calling fn
+ * @param args optional arguments forwarded to fn
+ */
+export function withSpan<
+  A extends unknown[],
+  F extends (...args: A) => ReturnType<F>
+>(
+  span: Span,
+  fn: F,
+  thisArg?: ThisParameterType<F>,
+  ...args: A
+): ReturnType<F> {
+  const ctx = setSpan(context.active(), span);
+  return context.with(ctx, fn, thisArg, ...args);
 }
 
 /**

--- a/test/internal/global.test.ts
+++ b/test/internal/global.test.ts
@@ -46,6 +46,12 @@ describe('Global Utils', () => {
     delete _globalThis[Symbol.for('io.opentelemetry.js.api.0')];
   });
 
+  afterEach(() => {
+    api1.context.disable();
+    api1.propagation.disable();
+    api1.trace.disable();
+  });
+
   it('should change the global context manager', () => {
     const original = api1.context['_getContextManager']();
     const newContextManager = new NoopContextManager();


### PR DESCRIPTION
fixes: open-telemetry/opentelemetry-js#1923

Continuing on @Flarna's work from https://github.com/open-telemetry/opentelemetry-js-api/pull/7

Though it seems like https://github.com/open-telemetry/opentelemetry-js/issues/1923 is where namespaced vs non-namespaced decision will be made. I will post there and ask for a tl;dr as to which it should be.