### PR TITLE
Add ESM build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,18 +3,20 @@
   "version": "1.0.0-rc.0",
   "description": "Public API for OpenTelemetry",
   "main": "build/src/index.js",
+  "module": "build/lib/index.js",
   "types": "build/src/index.d.ts",
   "browser": {
     "./src/platform/index.ts": "./src/platform/browser/index.ts",
+    "./build/lib/platform/index.js": "./build/lib/platform/browser/index.js",
     "./build/src/platform/index.js": "./build/src/platform/browser/index.js"
   },
   "repository": "https://github.com/open-telemetry/opentelemetry-js-api.git",
   "scripts": {
     "build": "npm run compile",
-    "clean": "tsc --build --clean",
+    "clean": "tsc --build --clean tsconfig.json tsconfig.esm.json",
     "codecov:browser": "nyc report --reporter=json && codecov -f coverage/*.json -p .",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p .",
-    "compile": "tsc --build",
+    "compile": "tsc --build tsconfig.json tsconfig.esm.json",
     "docs": "typedoc",
     "docs:deploy": "gh-pages --dist docs/out",
     "docs:test": "linkinator docs/out --silent --skip david-dm.org",
@@ -40,6 +42,9 @@
     "node": ">=8.0.0"
   },
   "files": [
+    "build/lib/**/*.js",
+    "build/lib/**/*.js.map",
+    "build/lib/**/*.d.ts",
     "build/src/**/*.js",
     "build/src/**/*.js.map",
     "build/src/**/*.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "1.0.0-rc.0",
   "description": "Public API for OpenTelemetry",
   "main": "build/src/index.js",
-  "module": "build/lib/index.js",
+  "module": "build/esm/index.js",
   "types": "build/src/index.d.ts",
   "browser": {
     "./src/platform/index.ts": "./src/platform/browser/index.ts",
-    "./build/lib/platform/index.js": "./build/lib/platform/browser/index.js",
+    "./build/esm/platform/index.js": "./build/esm/platform/browser/index.js",
     "./build/src/platform/index.js": "./build/src/platform/browser/index.js"
   },
   "repository": "https://github.com/open-telemetry/opentelemetry-js-api.git",
@@ -42,9 +42,9 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "build/lib/**/*.js",
-    "build/lib/**/*.js.map",
-    "build/lib/**/*.d.ts",
+    "build/esm/**/*.js",
+    "build/esm/**/*.js.map",
+    "build/esm/**/*.d.ts",
     "build/src/**/*.js",
     "build/src/**/*.js.map",
     "build/src/**/*.d.ts",

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -3,9 +3,9 @@
   "compilerOptions": {
     "module": "ES6",
     "moduleResolution": "node",
-    "outDir": "build/lib",
+    "outDir": "build/esm",
     "rootDir": "src",
-    "tsBuildInfoFile": "build/lib/tsconfig.esm.tsbuildinfo"
+    "tsBuildInfoFile": "build/esm/tsconfig.esm.tsbuildinfo"
   },
   "include": [
     "src/**/*.ts"

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ES6",
+    "moduleResolution": "node",
+    "outDir": "build/lib",
+    "rootDir": "src",
+    "tsBuildInfoFile": "build/lib/tsconfig.esm.tsbuildinfo"
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+}


### PR DESCRIPTION
# Why

While typescript uses ESM syntax, the code distributed on npm (build dir) has been transpiled to use commonjs require's for better compatibility. However this means that bundlers like webpack and rollup can't do tree shaking to remove code not imported by user, leaving behind unused dead code.

While `@opentelemetry/api` has lesser tree shake potential [due to code with side effects](https://github.com/open-telemetry/opentelemetry-js-api/blob/504041a8aa8442987a95f675af0a402084678682/src/index.ts#L60), I figured the best way to tackle this is to first target the one package in it's own repo, and once good implementation is figured out copy it to packages in open-telemetry/opentelemetry-js and open-telemetry/opentelemetry-js-contrib.

Relevant:
open-telemetry/opentelemetry-js#1378
open-telemetry/opentelemetry-js#1253

### How about using type: module and exports? ([as shown off by this tweet](https://twitter.com/_developit/status/1347296236282523648))

<details>
<summary>It's plausible but it may requires changes that might not be the best to do right before 1.0.0 release. Open this section for my attempt at it</summary>

```js
// package.json
{
  "type": "module",
  "exports": {
    ".": "./build/lib/index.js",
    "./lib/platform/index.js": {
      "browser": "./build/lib/platform/browser/index.js",
      "default": "./build/lib/platform/node/index.js"
    },
    "./lib": "./build/lib/*.js"
  },
}
```

While this will work instantly with rollup, there were issues with webpack and node.js. And well, second likely explains first. When package.json has type: module, node v12+ will also expect to see ESM code in *.js files and will use the file pointed exports map. There is however a difference - [node.js requires file extensions when importing from files](https://nodejs.org/api/esm.html#esm_mandatory_file_extensions):

```
node:internal/process/esm_loader:74
    internalBinding('errors').triggerUncaughtException(
                              ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find module 'repos/opentelemetry-js-api/lib/baggage/internal/baggage' imported from repos/opentelemetry-js-api/lib/baggage/index.js
```

Similar error was also given by webpack, so it's probably just them copying nodejs behaviour

This can be fixed by [adding .js to the end of imports in .ts files](https://github.com/t2t2/opentelemetry-js-api/commit/6ce23e95ec5c3143f8436b3ac16bdfcbd2c7cc1a#diff-a1b276cf28be065f7905a93c969700e3c86762339ce5c4aaafd11030ad542931) which seems odd as js files don't exist until built, but [is the recommended way](https://github.com/microsoft/TypeScript/issues/16577#issuecomment-703190339)

There's also considerations needed for [possible duplicated code loading when used by both esm and commonjs consumers](https://nodejs.org/api/packages.html#packages_dual_commonjs_es_module_packages) and possible backwards compatibility breakage for imports from direct files (`import ... from '@opentelemetry/api/build/src/....`), so would rather not try to do all of this right now.
</details> 

### How well does it work?

As noted above, due to side effects in index.ts it won't throw everything unneeded away but doing this over-simplified and totally unrealistic example:

```ts
import {INVALID_SPANID} from '@opentelemetry/api';

console.log(INVALID_SPANID);
```

* Rollup configured with nodeResolve, commonjs and typescript plugins
* webpack with `mode: development` and `optimization.concatenateModules = true`(does tree shaking, is enabled with mode: production but I wanted to check human-readable output for signs of shaking)

```
# Using currently published @opentelemetry/api:

 82671 23 Mar 16:33 build/pre-esm/rollup/index.js
106104 23 Mar 16:31 build/pre-esm/webpack/index.js

after doing:
repos/opentelemetry-js-api % npm link
repos/test-bundling % npm link @opentelemetry/api

 48425 24 Mar 11:57 build/rollup/index.js
 69957 24 Mar 12:02 build/webpack/index.js
```

### Potential improvements

* ESM versions could be used to ship code targeting newer targets (since esm support starts from node.js 12, [es2019 can be considered](https://github.com/tsconfig/bases/blob/master/bases/node12.json)), allowing users to decide if they want to transpile for older browsers or only for latest versions, which could have smaller output. But this can be considered backwards compatibility breaking for those who don't transpile dependencies (as it used to be common to ignore node_modules for babel-loader)
* Maybe folder naming? I've usually seen `(root)/lib` used for files generated from `(root)/src` but keeping the current structure I left `build/src/` as-is and put esm version into `build/lib/`
* ~~Rollup seems to ignore file overrides in package.browser~~ was missing [browser option in `@rollup/plugin-node-resolve`](https://github.com/rollup/plugins/tree/master/packages/node-resolve#browser), works as expected with that