### PR TITLE
chore: rename `span#context()` to `span#spanContext`

### DIFF
--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -75,7 +75,7 @@ export function setSpanContext(
  * @param context context to get values from
  */
 export function getSpanContext(context: Context): SpanContext | undefined {
-  return getSpan(context)?.context();
+  return getSpan(context)?.spanContext();
 }
 
 /**

--- a/src/trace/NoopSpan.ts
+++ b/src/trace/NoopSpan.ts
@@ -33,7 +33,7 @@ export class NoopSpan implements Span {
   ) {}
 
   // Returns a SpanContext.
-  context(): SpanContext {
+  spanContext(): SpanContext {
     return this._spanContext;
   }
 

--- a/src/trace/span.ts
+++ b/src/trace/span.ts
@@ -39,7 +39,7 @@ export interface Span {
    *
    * @returns the SpanContext object associated with this Span.
    */
-  context(): SpanContext;
+  spanContext(): SpanContext;
 
   /**
    * Sets an attribute to the span.

--- a/test/noop-implementations/noop-span.test.ts
+++ b/test/noop-implementations/noop-span.test.ts
@@ -44,7 +44,7 @@ describe('NoopSpan', () => {
     span.updateName('my-span');
 
     assert.ok(!span.isRecording());
-    assert.deepStrictEqual(span.context(), {
+    assert.deepStrictEqual(span.spanContext(), {
       traceId: INVALID_TRACEID,
       spanId: INVALID_SPANID,
       traceFlags: TraceFlags.NONE,

--- a/test/noop-implementations/noop-tracer.test.ts
+++ b/test/noop-implementations/noop-tracer.test.ts
@@ -52,8 +52,8 @@ describe('NoopTracer', () => {
       {},
       setSpanContext(context.active(), parent)
     );
-    assert(span.context().traceId === parent.traceId);
-    assert(span.context().spanId === parent.spanId);
-    assert(span.context().traceFlags === parent.traceFlags);
+    assert(span.spanContext().traceId === parent.traceId);
+    assert(span.spanContext().spanId === parent.spanId);
+    assert(span.spanContext().traceFlags === parent.traceFlags);
   });
 });


### PR DESCRIPTION
Fixes #35 