### PR TITLE
feat: add tracer.startActiveSpan()

### DIFF
--- a/src/trace/ProxyTracer.ts
+++ b/src/trace/ProxyTracer.ts
@@ -38,6 +38,16 @@ export class ProxyTracer implements Tracer {
     return this._getTracer().startSpan(name, options, context);
   }
 
+  startActiveSpan<F extends (span: Span) => unknown>(
+    _name: string,
+    _options: F | SpanOptions,
+    _context?: F | Context,
+    _fn?: F
+  ): ReturnType<F> {
+    const tracer = this._getTracer();
+    return Reflect.apply(tracer.startActiveSpan, tracer, arguments);
+  }
+
   /**
    * Try to get a tracer from the proxy tracer provider.
    * If the proxy tracer provider has no delegate, return a noop tracer.

--- a/src/trace/tracer.ts
+++ b/src/trace/tracer.ts
@@ -37,4 +37,63 @@ export interface Tracer {
    *     span.end();
    */
   startSpan(name: string, options?: SpanOptions, context?: Context): Span;
+
+  /**
+   * Starts a new {@link Span} and calls the given function passing it the
+   * created span as first argument.
+   * Additionally the new span gets set in context and this context is activated
+   * for the duration of the function call.
+   *
+   * @param name The name of the span
+   * @param [options] SpanOptions used for span creation
+   * @param [context] Context to use to extract parent
+   * @param fn function called in the context of the span and receives the newly created span as an argument
+   * @returns return value of fn
+   * @example
+   *   const something = tracer.startActiveSpan('op', span => {
+   *     try {
+   *       do some work
+   *       span.setStatus({code: SpanStatusCode.OK});
+   *       return something;
+   *     } catch (err) {
+   *       span.setStatus({
+   *         code: SpanStatusCode.ERROR,
+   *         message: err.message,
+   *       });
+   *       throw err;
+   *     } finally {
+   *       span.end();
+   *     }
+   *   });
+   * @example
+   *   const span = tracer.startActiveSpan('op', span => {
+   *     try {
+   *       do some work
+   *       return span;
+   *     } catch (err) {
+   *       span.setStatus({
+   *         code: SpanStatusCode.ERROR,
+   *         message: err.message,
+   *       });
+   *       throw err;
+   *     }
+   *   });
+   *   do some more work
+   *   span.end();
+   */
+  startActiveSpan<F extends (span: Span) => unknown>(
+    name: string,
+    fn: F
+  ): ReturnType<F>;
+  startActiveSpan<F extends (span: Span) => unknown>(
+    name: string,
+    options: SpanOptions,
+    fn: F
+  ): ReturnType<F>;
+  startActiveSpan<F extends (span: Span) => unknown>(
+    name: string,
+    options: SpanOptions,
+    context: Context,
+    fn: F
+  ): ReturnType<F>;
 }

--- a/test/noop-implementations/noop-tracer.test.ts
+++ b/test/noop-implementations/noop-tracer.test.ts
@@ -16,12 +16,13 @@
 
 import * as assert from 'assert';
 import {
+  context,
   NoopTracer,
+  Span,
   SpanContext,
   SpanKind,
-  TraceFlags,
-  context,
   trace,
+  TraceFlags,
 } from '../../src';
 import { NonRecordingSpan } from '../../src/trace/NonRecordingSpan';
 
@@ -55,5 +56,29 @@ describe('NoopTracer', () => {
     assert(span.spanContext().traceId === parent.traceId);
     assert(span.spanContext().spanId === parent.spanId);
     assert(span.spanContext().traceFlags === parent.traceFlags);
+  });
+
+  it('should accept 2 to 4 args and start an active span', () => {
+    const tracer = new NoopTracer();
+    const name = 'span-name';
+    const fn = (span: Span) => {
+      try {
+        return 1;
+      } finally {
+        span.end();
+      }
+    };
+    const opts = { attributes: { foo: 'bar' } };
+    const ctx = context.active();
+
+    const a = tracer.startActiveSpan(name, fn);
+    assert.strictEqual(a, 1);
+
+    const b = tracer.startActiveSpan(name, opts, fn);
+
+    assert.strictEqual(b, 1);
+
+    const c = tracer.startActiveSpan(name, opts, ctx, fn);
+    assert.strictEqual(c, 1);
   });
 });


### PR DESCRIPTION
adds helper function tracer.startActiveSpan()  which creates a new span and activates it in the current Context
