### PR TITLE
chore: move baggage methods in propagation namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Because the npm installer and node module resolution algorithm could potentially
 - `HttpBaggage` renamed to `HttpBaggagePropagator`
 - [#45](https://github.com/open-telemetry/opentelemetry-js-api/pull/45) `Span#context` renamed to `Span#spanContext`
 - [#47](https://github.com/open-telemetry/opentelemetry-js-api/pull/47) `getSpan`/`setSpan`/`getSpanContext`/`setSpanContext` moved to `trace` namespace
+- [#55](https://github.com/open-telemetry/opentelemetry-js-api/pull/55) `getBaggage`/`setBaggage`/`createBaggage` moved to `propagation` namespace
 
 ## Useful links
 

--- a/src/api/propagation.ts
+++ b/src/api/propagation.ts
@@ -28,6 +28,7 @@ import {
   registerGlobal,
   unregisterGlobal,
 } from '../internal/global-utils';
+import { getBaggage, createBaggage, setBaggage } from '../baggage/index';
 
 const API_NAME = 'propagation';
 
@@ -99,6 +100,12 @@ export class PropagationAPI {
   public disable() {
     unregisterGlobal(API_NAME);
   }
+
+  public createBaggage = createBaggage;
+
+  public getBaggage = getBaggage;
+
+  public setBaggage = setBaggage;
 
   private _getGlobalPropagator(): TextMapPropagator {
     return getGlobal(API_NAME) || NOOP_TEXT_MAP_PROPAGATOR;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export * from './baggage';
+export { baggageEntryMetadataFromString } from './baggage';
 export * from './common/Exception';
 export * from './common/Time';
 export * from './diag';

--- a/test/baggage/Baggage.test.ts
+++ b/test/baggage/Baggage.test.ts
@@ -16,24 +16,22 @@
 
 import * as assert from 'assert';
 import {
-  createBaggage,
-  setBaggage,
-  getBaggage,
   ROOT_CONTEXT,
+  propagation,
   baggageEntryMetadataFromString,
 } from '../../src';
 
 describe('Baggage', () => {
   describe('create', () => {
     it('should create an empty bag', () => {
-      const bag = createBaggage();
+      const bag = propagation.createBaggage();
 
       assert.deepStrictEqual(bag.getAllEntries(), []);
     });
 
     it('should create a bag with entries', () => {
       const meta = baggageEntryMetadataFromString('opaque string');
-      const bag = createBaggage({
+      const bag = propagation.createBaggage({
         key1: { value: 'value1' },
         key2: { value: 'value2', metadata: meta },
       });
@@ -47,7 +45,9 @@ describe('Baggage', () => {
 
   describe('get', () => {
     it('should not allow modification of returned entries', () => {
-      const bag = createBaggage().setEntry('key', { value: 'value' });
+      const bag = propagation
+        .createBaggage()
+        .setEntry('key', { value: 'value' });
 
       const entry = bag.getEntry('key');
       assert.ok(entry);
@@ -59,7 +59,7 @@ describe('Baggage', () => {
 
   describe('set', () => {
     it('should create a new bag when an entry is added', () => {
-      const bag = createBaggage();
+      const bag = propagation.createBaggage();
 
       const bag2 = bag.setEntry('key', { value: 'value' });
 
@@ -73,7 +73,7 @@ describe('Baggage', () => {
 
   describe('remove', () => {
     it('should create a new bag when an entry is removed', () => {
-      const bag = createBaggage({
+      const bag = propagation.createBaggage({
         key: { value: 'value' },
       });
 
@@ -87,7 +87,7 @@ describe('Baggage', () => {
     });
 
     it('should create an empty bag multiple keys are removed', () => {
-      const bag = createBaggage({
+      const bag = propagation.createBaggage({
         key: { value: 'value' },
         key1: { value: 'value1' },
         key2: { value: 'value2' },
@@ -107,7 +107,7 @@ describe('Baggage', () => {
     });
 
     it('should create an empty bag when it cleared', () => {
-      const bag = createBaggage({
+      const bag = propagation.createBaggage({
         key: { value: 'value' },
         key1: { value: 'value1' },
       });
@@ -125,11 +125,11 @@ describe('Baggage', () => {
 
   describe('context', () => {
     it('should set and get a baggage from a context', () => {
-      const bag = createBaggage();
+      const bag = propagation.createBaggage();
 
-      const ctx = setBaggage(ROOT_CONTEXT, bag);
+      const ctx = propagation.setBaggage(ROOT_CONTEXT, bag);
 
-      assert.strictEqual(bag, getBaggage(ctx));
+      assert.strictEqual(bag, propagation.getBaggage(ctx));
     });
   });
 
@@ -148,7 +148,7 @@ describe('Baggage', () => {
     });
 
     it('should retain metadata', () => {
-      const bag = createBaggage({
+      const bag = propagation.createBaggage({
         key: {
           value: 'value',
           metadata: baggageEntryMetadataFromString('meta'),


### PR DESCRIPTION
Since we moved the span context method into `trace` namespace, i'm also proposing to move `[create/get/set]Baggage` into the `propagation` namespace.

We still export `baggageEntryMetadataFromString` which feels kinda wrong to me since it doesn't do anything apart creating a unusued object, could we have a less strict type for the metadata so we don't need this function ?