### PR TITLE
feat: unify signatures of `with` and `bind`

### DIFF
--- a/src/api/context.ts
+++ b/src/api/context.ts
@@ -78,22 +78,14 @@ export class ContextAPI {
 
   /**
    * Bind a context to a target function or event emitter
-   * @deprecated in 0.x, will be removed in 1.x
-   *
-   * @param target function or event emitter to bind
-   * @param context context to bind to the event emitter or function. Defaults to the currently active context
-   */
-  public bind<T>(target: T, context: Context = this.active()): T {
-    return this._getContextManager().bind(target, context);
-  }
-
-  /**
-   * Bind a context to a target function or event emitter
    *
    * @param context context to bind to the event emitter or function. Defaults to the currently active context
    * @param target function or event emitter to bind
    */
-  public bind<T>(context: Context = this.active(), target: T): T {
+  public bind<T>(context: Context, target: T): T {
+    if (context === undefined) {
+      return target;
+    }
     return this._getContextManager().bind(target, context);
   }
 

--- a/src/api/context.ts
+++ b/src/api/context.ts
@@ -78,11 +78,22 @@ export class ContextAPI {
 
   /**
    * Bind a context to a target function or event emitter
+   * @deprecated in 0.x, will be removed in 1.x
    *
    * @param target function or event emitter to bind
    * @param context context to bind to the event emitter or function. Defaults to the currently active context
    */
   public bind<T>(target: T, context: Context = this.active()): T {
+    return this._getContextManager().bind(target, context);
+  }
+
+  /**
+   * Bind a context to a target function or event emitter
+   *
+   * @param context context to bind to the event emitter or function. Defaults to the currently active context
+   * @param target function or event emitter to bind
+   */
+  public bind<T>(context: Context = this.active(), target: T): T {
     return this._getContextManager().bind(target, context);
   }
 

--- a/src/api/context.ts
+++ b/src/api/context.ts
@@ -83,10 +83,7 @@ export class ContextAPI {
    * @param target function or event emitter to bind
    */
   public bind<T>(context: Context, target: T): T {
-    if (context === undefined) {
-      return target;
-    }
-    return this._getContextManager().bind(target, context);
+    return this._getContextManager().bind(context, target);
   }
 
   private _getContextManager(): ContextManager {

--- a/src/context/NoopContextManager.ts
+++ b/src/context/NoopContextManager.ts
@@ -31,7 +31,7 @@ export class NoopContextManager implements types.ContextManager {
     return fn.call(thisArg, ...args);
   }
 
-  bind<T>(target: T, _context?: types.Context): T {
+  bind<T>(_context: types.Context, target: T): T {
     return target;
   }
 

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -65,7 +65,7 @@ export interface ContextManager {
    * @param target Any object to which a context need to be set
    * @param [context] Optionally specify the context which you want to assign
    */
-  bind<T>(target: T, context?: Context): T;
+  bind<T>(context: Context, target: T): T;
 
   /**
    * Enable context management

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -62,8 +62,8 @@ export interface ContextManager {
 
   /**
    * Bind an object as the current context (or a specific one)
-   * @param target Any object to which a context need to be set
    * @param [context] Optionally specify the context which you want to assign
+   * @param target Any object to which a context need to be set
    */
   bind<T>(context: Context, target: T): T;
 

--- a/test/context/NoopContextManager.test.ts
+++ b/test/context/NoopContextManager.test.ts
@@ -119,13 +119,19 @@ describe('NoopContextManager', () => {
   describe('.bind()', () => {
     it('should return the same target (when enabled)', () => {
       const test = { a: 1 };
-      assert.deepStrictEqual(contextManager.bind(contextManager.active(), test), test);
+      assert.deepStrictEqual(
+        contextManager.bind(contextManager.active(), test),
+        test
+      );
     });
 
     it('should return the same target (when disabled)', () => {
       contextManager.disable();
       const test = { a: 1 };
-      assert.deepStrictEqual(contextManager.bind(contextManager.active(), test), test);
+      assert.deepStrictEqual(
+        contextManager.bind(contextManager.active(), test),
+        test
+      );
       contextManager.enable();
     });
   });

--- a/test/context/NoopContextManager.test.ts
+++ b/test/context/NoopContextManager.test.ts
@@ -119,13 +119,13 @@ describe('NoopContextManager', () => {
   describe('.bind()', () => {
     it('should return the same target (when enabled)', () => {
       const test = { a: 1 };
-      assert.deepStrictEqual(contextManager.bind(test), test);
+      assert.deepStrictEqual(contextManager.bind(contextManager.active(), test), test);
     });
 
     it('should return the same target (when disabled)', () => {
       contextManager.disable();
       const test = { a: 1 };
-      assert.deepStrictEqual(contextManager.bind(test), test);
+      assert.deepStrictEqual(contextManager.bind(contextManager.active(), test), test);
       contextManager.enable();
     });
   });


### PR DESCRIPTION
Just like `Function.prototype.apply`, `Function.prototype.call` and `Function.prototype.bind` have the same signature, it would make sense for `context.with` and `context.bind` to do the same to prevent confusion among the instrumentation developers(I know I have made the mistake a few times).

Having `context` as the first argument also makes intuitive sense, to me at least, even without considering the signature of `context.with` - probably because of how `Function.prototype.bind` works.

One drawback for this is the fact that the function argument to both of those methods is more "stable" - meaning that making the function an optional parameter makes no sense, but context, on the other hand, has an intuitive default: the active context. So:

```
api.context.bind(undefined, () => {
  // binds to active context.
});
```

@vmarchaud makes that point in a [slack thread](https://cloud-native.slack.com/archives/C01NL1GRPQR/p1620392557143900):

> `context.with` is used to apply a context within the callback function, it doesn't make sense to use it if you don't want to change the context
> whereas `context.bind` is used to correctly propagate the context even if the method is known to "break" propagation like events emitter, so it makes sense to bind the current context in this case

**This PR is a hypothetical one to spawn discussion on the topic, the actual implementation needs, for the time being, do some parameter type checking in `context.bind`, which can be removed before the release of 1.x.**
Unless this change gets significant pushback, I to do the same change in Context Manager's APIs as well and prepare another PR to be merged before 1.0 removing deprecated options.

Implemented the way it is right now, this is **BREAKING CHANGE**.