### PR TITLE
chore: remove circular dependency

### DIFF
--- a/src/api/context.ts
+++ b/src/api/context.ts
@@ -21,6 +21,7 @@ import {
   registerGlobal,
   unregisterGlobal,
 } from '../internal/global-utils';
+import { DiagAPI } from './diag';
 
 const API_NAME = 'context';
 const NOOP_CONTEXT_MANAGER = new NoopContextManager();
@@ -49,7 +50,7 @@ export class ContextAPI {
    * @returns true if the context manager was successfully registered, else false
    */
   public setGlobalContextManager(contextManager: ContextManager): boolean {
-    return registerGlobal(API_NAME, contextManager);
+    return registerGlobal(API_NAME, contextManager, DiagAPI.instance());
   }
 
   /**
@@ -93,6 +94,6 @@ export class ContextAPI {
   /** Disable and remove the global context manager */
   public disable() {
     this._getContextManager().disable();
-    unregisterGlobal(API_NAME);
+    unregisterGlobal(API_NAME, DiagAPI.instance());
   }
 }

--- a/src/api/diag.ts
+++ b/src/api/diag.ts
@@ -96,11 +96,11 @@ export class DiagAPI implements DiagLogger {
         );
       }
 
-      return registerGlobal('diag', newLogger, true);
+      return registerGlobal('diag', newLogger, self, true);
     };
 
     self.disable = () => {
-      unregisterGlobal(API_NAME);
+      unregisterGlobal(API_NAME, self);
     };
 
     self.createComponentLogger = (options: ComponentLoggerOptions) => {

--- a/src/api/propagation.ts
+++ b/src/api/propagation.ts
@@ -34,6 +34,7 @@ import {
   deleteBaggage,
 } from '../baggage/context-helpers';
 import { createBaggage } from '../baggage/utils';
+import { DiagAPI } from './diag';
 
 const API_NAME = 'propagation';
 const NOOP_TEXT_MAP_PROPAGATOR = new NoopTextMapPropagator();
@@ -62,7 +63,7 @@ export class PropagationAPI {
    * @returns true if the propagator was successfully registered, else false
    */
   public setGlobalPropagator(propagator: TextMapPropagator): boolean {
-    return registerGlobal(API_NAME, propagator);
+    return registerGlobal(API_NAME, propagator, DiagAPI.instance());
   }
 
   /**
@@ -104,7 +105,7 @@ export class PropagationAPI {
 
   /** Remove the global propagator */
   public disable() {
-    unregisterGlobal(API_NAME);
+    unregisterGlobal(API_NAME, DiagAPI.instance());
   }
 
   public createBaggage = createBaggage;

--- a/src/api/trace.ts
+++ b/src/api/trace.ts
@@ -33,6 +33,7 @@ import {
   setSpan,
   setSpanContext,
 } from '../trace/context-utils';
+import { DiagAPI } from './diag';
 
 const API_NAME = 'trace';
 
@@ -63,7 +64,11 @@ export class TraceAPI {
    */
   public setGlobalTracerProvider(provider: TracerProvider): boolean {
     this._proxyTracerProvider.setDelegate(provider);
-    return registerGlobal(API_NAME, this._proxyTracerProvider);
+    return registerGlobal(
+      API_NAME,
+      this._proxyTracerProvider,
+      DiagAPI.instance()
+    );
   }
 
   /**
@@ -82,7 +87,7 @@ export class TraceAPI {
 
   /** Remove the global tracer provider */
   public disable() {
-    unregisterGlobal(API_NAME);
+    unregisterGlobal(API_NAME, DiagAPI.instance());
     this._proxyTracerProvider = new ProxyTracerProvider();
   }
 

--- a/src/internal/global-utils.ts
+++ b/src/internal/global-utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { diag } from '..';
+import type { DiagAPI } from '../api/diag';
 import { ContextManager } from '../context/types';
 import { DiagLogger } from '../diag';
 import { _globalThis } from '../platform';
@@ -33,6 +33,7 @@ const _global = _globalThis as OTelGlobal;
 export function registerGlobal<Type extends keyof OTelGlobalAPI>(
   type: Type,
   instance: OTelGlobalAPI[Type],
+  diag: DiagAPI,
   allowOverride = false
 ): boolean {
   const api = (_global[GLOBAL_OPENTELEMETRY_API_KEY] = _global[
@@ -77,7 +78,7 @@ export function getGlobal<Type extends keyof OTelGlobalAPI>(
   return _global[GLOBAL_OPENTELEMETRY_API_KEY]?.[type];
 }
 
-export function unregisterGlobal(type: keyof OTelGlobalAPI) {
+export function unregisterGlobal(type: keyof OTelGlobalAPI, diag: DiagAPI) {
   diag.debug(
     `@opentelemetry/api: Unregistering a global for ${type} v${VERSION}.`
   );


### PR DESCRIPTION
Fixes #87 

The `global-utils.ts` depends on the `diag` API, which depends on `global-utils`. This results in a circular dependency.

Resolve by injecting the `diag` instance into the function at call time.

/cc @MSNev 