### PR TITLE
feat: allow setting attributes when recording exceptions

### DIFF
--- a/src/trace/NonRecordingSpan.ts
+++ b/src/trace/NonRecordingSpan.ts
@@ -71,5 +71,9 @@ export class NonRecordingSpan implements Span {
   }
 
   // By default does nothing
-  recordException(_exception: Exception, _time?: TimeInput): void {}
+  recordException(
+    _exception: Exception,
+    _attributesOrTime?: SpanAttributes | TimeInput,
+    _time?: TimeInput
+  ): void {}
 }

--- a/src/trace/NonRecordingSpan.ts
+++ b/src/trace/NonRecordingSpan.ts
@@ -48,7 +48,11 @@ export class NonRecordingSpan implements Span {
   }
 
   // By default does nothing
-  addEvent(_name: string, _attributes?: SpanAttributes): this {
+  addEvent(
+    _name: string,
+    _attributesOrTime?: SpanAttributes | TimeInput,
+    _time?: TimeInput
+  ): this {
     return this;
   }
 

--- a/src/trace/span.ts
+++ b/src/trace/span.ts
@@ -65,14 +65,21 @@ export interface Span {
    * Adds an event to the Span.
    *
    * @param name the name of the event.
-   * @param [attributesOrStartTime] the attributes that will be added; these are
-   *     associated with this event. Can be also a start time
-   *     if type is {@type TimeInput} and 3rd param is undefined
+   * @param [startTime] start time of the event.
+   */
+  addEvent(name: string, startTime?: TimeInput): this;
+
+  /**
+   * Adds an event to the Span.
+   *
+   * @param name the name of the event.
+   * @param [attributes] the attributes that will be added; these are
+   *     associated with this event.
    * @param [startTime] start time of the event.
    */
   addEvent(
     name: string,
-    attributesOrStartTime?: SpanAttributes | TimeInput,
+    attributes?: SpanAttributes,
     startTime?: TimeInput
   ): this;
 
@@ -123,15 +130,22 @@ export interface Span {
    * Sets exception as a span event.
    *
    * @param exception the exception the only accepted values are string or Error
-   * @param [attributesOrTime] additional attributes to be associated with
-   *     this event. Can also be the time parameter if type is {@type TimeInput}
-   *     and 3rd parameter is undefined.
+   * @param [time] the time to set as Span's event time. If not provided,
+   *     use the current time.
+   */
+  recordException(exception: Exception, time?: TimeInput): void;
+
+  /**
+   * Sets exception as a span event.
+   *
+   * @param exception the exception the only accepted values are string or Error
+   * @param [attributes] additional attributes to be associated with this event.
    * @param [time] the time to set as Span's event time. If not provided,
    *     use the current time.
    */
   recordException(
     exception: Exception,
-    attributesOrTime?: SpanAttributes | TimeInput,
+    attributes?: SpanAttributes,
     time?: TimeInput
   ): void;
 }

--- a/src/trace/span.ts
+++ b/src/trace/span.ts
@@ -120,10 +120,18 @@ export interface Span {
   isRecording(): boolean;
 
   /**
-   * Sets exception as a span event
+   * Sets exception as a span event.
+   *
    * @param exception the exception the only accepted values are string or Error
+   * @param [attributesOrTime] additional attributes to be associated with
+   *     this event. Can also be the time parameter if type is {@type TimeInput}
+   *     and 3rd parameter is undefined.
    * @param [time] the time to set as Span's event time. If not provided,
    *     use the current time.
    */
-  recordException(exception: Exception, time?: TimeInput): void;
+  recordException(
+    exception: Exception,
+    attributesOrTime?: SpanAttributes | TimeInput,
+    time?: TimeInput
+  ): void;
 }


### PR DESCRIPTION
* span.recordException needs to allow settings event attributes per [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#record-exception)
> If RecordException is provided, the method MUST accept an optional parameter to provide any additional event attributes (this SHOULD be done in the same way as for the AddEvent method). If attributes with the same name would be generated by the method already, the additional attributes take precedence.
* Fixes #95 