### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,13 +56,13 @@
   },
   "devDependencies": {
     "@types/mocha": "8.2.2",
-    "@types/node": "14.17.1",
+    "@types/node": "14.17.4",
     "@types/sinon": "10.0.2",
     "@types/webpack-env": "1.16.0",
-    "@typescript-eslint/eslint-plugin": "4.26.0",
-    "@typescript-eslint/parser": "4.26.0",
+    "@typescript-eslint/eslint-plugin": "4.28.1",
+    "@typescript-eslint/parser": "4.28.1",
     "codecov": "3.8.2",
-    "eslint": "7.28.0",
+    "eslint": "7.29.0",
     "eslint-plugin-header": "3.1.1",
     "eslint-plugin-import": "2.23.4",
     "gh-pages": "3.2.0",
@@ -81,8 +81,8 @@
     "sinon": "11.1.1",
     "ts-loader": "8.2.0",
     "ts-mocha": "8.0.0",
-    "typedoc": "0.21.0-beta.1",
-    "typescript": "4.3.2",
+    "typedoc": "0.21.2",
+    "typescript": "4.3.4",
     "webpack": "4.46.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@typescript-eslint/eslint-plugin": "4.28.1",
     "@typescript-eslint/parser": "4.28.1",
     "codecov": "3.8.2",
-    "eslint": "7.29.0",
+    "eslint": "7.30.0",
     "eslint-plugin-header": "3.1.1",
     "eslint-plugin-import": "2.23.4",
     "gh-pages": "3.2.0",
@@ -82,7 +82,7 @@
     "ts-loader": "8.2.0",
     "ts-mocha": "8.0.0",
     "typedoc": "0.21.2",
-    "typescript": "4.3.4",
+    "typescript": "4.3.5",
     "webpack": "4.46.0"
   }
 }


### PR DESCRIPTION
Update some dev-dependencies.
Mainly to get rid of the beta version of typedoc needed to use TS 4.3 `override` keyword.