### PR TITLE
docs: Format example for tracer.startActiveSpan

### DIFF
--- a/src/trace/tracer.ts
+++ b/src/trace/tracer.ts
@@ -50,36 +50,37 @@ export interface Tracer {
    * @param fn function called in the context of the span and receives the newly created span as an argument
    * @returns return value of fn
    * @example
-   *   const something = tracer.startActiveSpan('op', span => {
-   *     try {
-   *       do some work
-   *       span.setStatus({code: SpanStatusCode.OK});
-   *       return something;
-   *     } catch (err) {
-   *       span.setStatus({
-   *         code: SpanStatusCode.ERROR,
-   *         message: err.message,
-   *       });
-   *       throw err;
-   *     } finally {
-   *       span.end();
-   *     }
-   *   });
+   *     const something = tracer.startActiveSpan('op', span => {
+   *       try {
+   *         do some work
+   *         span.setStatus({code: SpanStatusCode.OK});
+   *         return something;
+   *       } catch (err) {
+   *         span.setStatus({
+   *           code: SpanStatusCode.ERROR,
+   *           message: err.message,
+   *         });
+   *         throw err;
+   *       } finally {
+   *         span.end();
+   *       }
+   *     });
+   *
    * @example
-   *   const span = tracer.startActiveSpan('op', span => {
-   *     try {
-   *       do some work
-   *       return span;
-   *     } catch (err) {
-   *       span.setStatus({
-   *         code: SpanStatusCode.ERROR,
-   *         message: err.message,
-   *       });
-   *       throw err;
-   *     }
-   *   });
-   *   do some more work
-   *   span.end();
+   *     const span = tracer.startActiveSpan('op', span => {
+   *       try {
+   *         do some work
+   *         return span;
+   *       } catch (err) {
+   *         span.setStatus({
+   *           code: SpanStatusCode.ERROR,
+   *           message: err.message,
+   *         });
+   *         throw err;
+   *       }
+   *     });
+   *     do some more work
+   *     span.end();
    */
   startActiveSpan<F extends (span: Span) => unknown>(
     name: string,


### PR DESCRIPTION
Example in documentation fro `tracer.startActiveSpan` is misformated:

![image](https://user-images.githubusercontent.com/3618479/124847187-a4562a00-df9a-11eb-9f0c-300e17f744b6.png)

That PR is gonna fix that:

![image](https://user-images.githubusercontent.com/3618479/124847243-bf289e80-df9a-11eb-8a9a-5be16e7e7682.png)

I have doubts whether the second example - although technically correct - is optimal for promotion and indication in the documentation.