### PR TITLE
fix: set delegate after successful registration

### DIFF
--- a/src/api/trace.ts
+++ b/src/api/trace.ts
@@ -63,12 +63,15 @@ export class TraceAPI {
    * @returns true if the tracer provider was successfully registered, else false
    */
   public setGlobalTracerProvider(provider: TracerProvider): boolean {
-    this._proxyTracerProvider.setDelegate(provider);
-    return registerGlobal(
+    const success = registerGlobal(
       API_NAME,
       this._proxyTracerProvider,
       DiagAPI.instance()
     );
+    if (success) {
+      this._proxyTracerProvider.setDelegate(provider);
+    }
+    return success;
   }
 
   /**

--- a/test/api/api.test.ts
+++ b/test/api/api.test.ts
@@ -93,6 +93,18 @@ describe('API', () => {
       assert.deepStrictEqual(span, dummySpan);
     });
 
+    it('should set delegate only on success', () => {
+      assert.strictEqual(
+        api.trace.setGlobalTracerProvider(new TestTracerProvider()),
+        true
+      );
+      assert.strictEqual(
+        api.trace.setGlobalTracerProvider(new NoopTracerProvider()),
+        false
+      );
+      assert.ok(api.trace.getTracer('name') instanceof TestTracer);
+    });
+
     class TestTracer extends NoopTracer {
       override startSpan(name: string, options?: SpanOptions): Span {
         return dummySpan;


### PR DESCRIPTION
Set the new TracerProvider as delegate in ProxyTracerProvider only if global registration was successful.

fixes: https://github.com/open-telemetry/opentelemetry-js-api/issues/104
