### PR TITLE
docs: fix crash in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ async function operation() {
   })
 
   span.end();
-  return output;
 }
 
 async function main() {


### PR DESCRIPTION
When running the example in the README before this change I get:

```
% node --trace-warnings example.js
{
  traceId: 'b0a511fe69ff65345b18db0486cb8568',
  parentId: undefined,
  name: 'do operation',
  id: '0ccd8ba64328a259',
  kind: 0,
  timestamp: 1626991645695433,
  duration: 1004811,
  attributes: {},
  status: { code: 0 },
  events: []
}
(node:47750) UnhandledPromiseRejectionWarning: ReferenceError: output is not defined
    at operation (/Users/trentm/tm/otelplay/example.js:24:3)
    at async main (/Users/trentm/tm/otelplay/example.js:29:5)
    at emitUnhandledRejectionWarning (internal/process/promises.js:168:15)
    at processPromiseRejections (internal/process/promises.js:247:11)
    at processTicksAndRejections (internal/process/task_queues.js:94:32)
(node:47750) ReferenceError: output is not defined
    at operation (/Users/trentm/tm/otelplay/example.js:24:3)
    at async main (/Users/trentm/tm/otelplay/example.js:29:5)
(node:47750) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
    at emitDeprecationWarning (internal/process/promises.js:180:11)
    at processPromiseRejections (internal/process/promises.js:249:13)
    at processTicksAndRejections (internal/process/task_queues.js:94:32)
```

Afterwards:

```
% node --trace-warnings example.js
{
  traceId: '1a7fad4ba55e693763457fb873a7c56b',
  parentId: undefined,
  name: 'do operation',
  id: '9b30b19524c006c6',
  kind: 0,
  timestamp: 1626991653931635,
  duration: 1004384,
  attributes: {},
  status: { code: 0 },
  events: []
}
{
  traceId: 'd38b7fc5ac00bfa32d3e62a5b2363a66',
  parentId: undefined,
  name: 'do operation',
  id: '9f1ef11fae2eec85',
  kind: 0,
  timestamp: 1626991654947103,
  duration: 1001100,
  attributes: {},
  status: { code: 0 },
  events: []
}
...
```