### PR TITLE
docs: fix rendering of tracer.startActiveSpan examples

### DIFF
--- a/src/trace/tracer.ts
+++ b/src/trace/tracer.ts
@@ -50,36 +50,36 @@ export interface Tracer {
    * @param fn function called in the context of the span and receives the newly created span as an argument
    * @returns return value of fn
    * @example
-   *   const something = tracer.startActiveSpan('op', span => {
-   *     try {
-   *       do some work
-   *       span.setStatus({code: SpanStatusCode.OK});
-   *       return something;
-   *     } catch (err) {
-   *       span.setStatus({
-   *         code: SpanStatusCode.ERROR,
-   *         message: err.message,
-   *       });
-   *       throw err;
-   *     } finally {
-   *       span.end();
-   *     }
-   *   });
+   *     const something = tracer.startActiveSpan('op', span => {
+   *       try {
+   *         do some work
+   *         span.setStatus({code: SpanStatusCode.OK});
+   *         return something;
+   *       } catch (err) {
+   *         span.setStatus({
+   *           code: SpanStatusCode.ERROR,
+   *           message: err.message,
+   *         });
+   *         throw err;
+   *       } finally {
+   *         span.end();
+   *       }
+   *     });
    * @example
-   *   const span = tracer.startActiveSpan('op', span => {
-   *     try {
-   *       do some work
-   *       return span;
-   *     } catch (err) {
-   *       span.setStatus({
-   *         code: SpanStatusCode.ERROR,
-   *         message: err.message,
-   *       });
-   *       throw err;
-   *     }
-   *   });
-   *   do some more work
-   *   span.end();
+   *     const span = tracer.startActiveSpan('op', span => {
+   *       try {
+   *         do some work
+   *         return span;
+   *       } catch (err) {
+   *         span.setStatus({
+   *           code: SpanStatusCode.ERROR,
+   *           message: err.message,
+   *         });
+   *         throw err;
+   *       }
+   *     });
+   *     do some more work
+   *     span.end();
    */
   startActiveSpan<F extends (span: Span) => unknown>(
     name: string,


### PR DESCRIPTION
Before (at https://open-telemetry.github.io/opentelemetry-js-api/interfaces/tracer.html):

![Screen Shot 2021-07-22 at 5 57 19 PM](https://user-images.githubusercontent.com/46866/126726363-1c7f333e-638b-4a72-b580-0f0bbdaa3ec1.png)

after:

![Screen Shot 2021-07-22 at 5 57 41 PM](https://user-images.githubusercontent.com/46866/126726384-0565fc3f-2313-43b3-8c88-c12f327d9105.png)


https://typedoc.org/guides/doccomments/ doesn't document the `@example` tag that I could see, so this is a guess that it meets the requirements to get picked up as a code block (given Markdown requires 4 leading spaces for that).