### PR TITLE
Update Dependencies 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: /
+  schedule:
+    interval: weekly
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 updates:
 - package-ecosystem: npm
+  open-pull-requests-limit: 30
   directory: /
   schedule:
     interval: weekly

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container: ["node:8", "node:10", "node:12", "node:14", "node:16"]
+        container: ["node:10", "node:12", "node:14", "node:16"]
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.container }}

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "eslint": "7.30.0",
     "eslint-plugin-header": "3.1.1",
     "eslint-plugin-import": "2.23.4",
-    "gh-pages": "3.2.0",
+    "gh-pages": "3.2.3",
     "gts": "3.1.0",
     "istanbul-instrumenter-loader": "3.0.1",
     "karma": "5.2.3",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/sinon": "10.0.2",
     "@types/webpack-env": "1.16.2",
     "@typescript-eslint/eslint-plugin": "4.28.1",
-    "@typescript-eslint/parser": "4.28.1",
+    "@typescript-eslint/parser": "4.28.4",
     "codecov": "3.8.3",
     "eslint": "7.31.0",
     "eslint-plugin-header": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "gh-pages": "3.2.3",
     "gts": "3.1.0",
     "istanbul-instrumenter-loader": "3.0.1",
-    "karma": "5.2.3",
+    "karma": "6.3.4",
     "karma-chrome-launcher": "3.1.0",
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-mocha": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@types/mocha": "8.2.2",
-    "@types/node": "14.17.4",
+    "@types/node": "16.4.2",
     "@types/sinon": "10.0.2",
     "@types/webpack-env": "1.16.2",
     "@typescript-eslint/eslint-plugin": "4.28.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@typescript-eslint/eslint-plugin": "4.28.1",
     "@typescript-eslint/parser": "4.28.1",
     "codecov": "3.8.3",
-    "eslint": "7.30.0",
+    "eslint": "7.31.0",
     "eslint-plugin-header": "3.1.1",
     "eslint-plugin-import": "2.23.4",
     "gh-pages": "3.2.3",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@types/mocha": "8.2.2",
+    "@types/mocha": "9.0.0",
     "@types/node": "16.4.2",
     "@types/sinon": "10.0.2",
     "@types/webpack-env": "1.16.2",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "4.0.2",
     "lerna-changelog": "1.0.1",
-    "linkinator": "2.13.6",
+    "linkinator": "2.14.0",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "sinon": "11.1.1",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "sinon": "11.1.1",
     "ts-loader": "8.2.0",
     "ts-mocha": "8.0.0",
-    "typedoc": "0.21.2",
+    "typedoc": "0.21.4",
     "typescript": "4.3.5",
     "webpack": "4.46.0"
   }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@types/webpack-env": "1.16.2",
     "@typescript-eslint/eslint-plugin": "4.28.1",
     "@typescript-eslint/parser": "4.28.1",
-    "codecov": "3.8.2",
+    "codecov": "3.8.3",
     "eslint": "7.30.0",
     "eslint-plugin-header": "3.1.1",
     "eslint-plugin-import": "2.23.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "files": [
     "build/esm/**/*.js",
@@ -55,7 +55,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@types/mocha": "9.0.0",
+    "@types/mocha": "8.2.2",
     "@types/node": "16.4.2",
     "@types/sinon": "10.0.2",
     "@types/webpack-env": "1.16.2",
@@ -76,7 +76,7 @@
     "karma-webpack": "4.0.2",
     "lerna-changelog": "1.0.1",
     "linkinator": "2.14.0",
-    "mocha": "7.2.0",
+    "mocha": "8.4.0",
     "nyc": "15.1.0",
     "sinon": "11.1.1",
     "ts-loader": "8.2.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/mocha": "8.2.2",
     "@types/node": "14.17.4",
     "@types/sinon": "10.0.2",
-    "@types/webpack-env": "1.16.0",
+    "@types/webpack-env": "1.16.2",
     "@typescript-eslint/eslint-plugin": "4.28.1",
     "@typescript-eslint/parser": "4.28.1",
     "codecov": "3.8.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@types/node": "16.4.2",
     "@types/sinon": "10.0.2",
     "@types/webpack-env": "1.16.2",
-    "@typescript-eslint/eslint-plugin": "4.28.1",
+    "@typescript-eslint/eslint-plugin": "4.28.4",
     "@typescript-eslint/parser": "4.28.4",
     "codecov": "3.8.3",
     "eslint": "7.31.0",


### PR DESCRIPTION
Node 8 is not supported : https://nodejs.org/en/about/releases/
Neither is 10 but it wasn't blocking the update of any dependency.
This also includes the configuration of dependabot for npm and github-actions dependencies 