### PR TITLE
chore: Add a script to automate releases

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -19,8 +19,8 @@ while [[ $# -gt 0 ]]; do
       FORCE=YES
       shift
       ;;
-    -c|--no-clean)
-      NOCLEAN=YES
+    -c|--clean)
+      CLEAN=YES
       shift
       ;;
     -l|--no-latest)
@@ -58,8 +58,8 @@ if [ -n "$HELP" ]; then
   echo -e "\t-f | --force"
   echo -e "\t\tForce execution even if there are uncommitted changes in the workspace"
   echo ""
-  echo -e "\t-c | --no-clean"
-  echo -e "\t\tDo not clean the workspace"
+  echo -e "\t-c | --clean"
+  echo -e "\t\tRemove all files from the workspace not tracked by git"
   echo ""
   echo -e "\t-l | --latest"
   echo -e "\t\tApply the NPM dist-tag @latest after publish"
@@ -71,12 +71,12 @@ if [ -n "$HELP" ]; then
 fi
 
 if [ ! -d ".git" ]; then
-  echo "Not in a git repository"
+  echo "Not in a git repository. Please make sure to run this from the root of the OpenTelemetry API repository."
   exit 1
 fi
 
 if changes=$(git status --porcelain) && [ -n "$changes" ] && [ -z "$FORCE" ]; then
-  echo "There are uncommitted changes in the workspace"
+  echo "There are uncommitted changes in the workspace. Please commit or stash the changes or run this command again with the --force option."
   echo $changes
   exit 1
 fi
@@ -84,7 +84,7 @@ fi
 [ -n "$DRY" ] && echo "Dry run"
 
 # Ensure working directory is clean if user has not specifically disabled cleaning
-if [ -z "$NOCLEAN" ]; then
+if [ -n "$CLEAN" ]; then
   echo "Cleaning workspace"
   echo "rm -rf node_modules"
   [ -z "$DRY" ] && rm -rf node_modules

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -108,8 +108,8 @@ echo "npm test"
 echo "npm publish --tag $TAG"
 [ -z "$DRY" ] && npm publish --tag $TAG
 
-echo "npm dist-tag add \"@opentelemetry/api@$TAG\" latest"
 if [ -n "$LATEST" ]; then
+  echo "npm dist-tag add \"@opentelemetry/api@$TAG\" latest"
   [ -z "$DRY" ] && npm dist-tag add "@opentelemetry/api@$TAG" latest
 fi
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+set -e
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+  key="$1"
+
+  case $key in
+    -h|--help)
+      HELP=YES
+      shift # past argument
+      ;;
+    -d|--dry-run)
+      DRY=YES
+      shift
+      ;;
+    -f|--force)
+      FORCE=YES
+      shift
+      ;;
+    -c|--no-clean)
+      NOCLEAN=YES
+      shift
+      ;;
+    -l|--no-latest)
+      LATEST=YES
+      shift
+      ;;
+    -t|--tag)
+      TAG="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    *)    # unknown option
+      POSITIONAL+=("$1") # save it in an array for later
+      shift # past argument
+      ;;
+  esac
+done
+
+if [ -z "$TAG" ]; then
+  TAG="next"
+fi
+
+if [ -n "$HELP" ]; then
+  echo "release.sh Usage:"
+  echo ""
+  echo "ALWAYS RUN FROM THE ROOT OF THE REPOSITORY"
+  echo ""
+  echo "Arguments:"
+  echo -e "\t-h | --help"
+  echo -e "\t\tDisplay this help message"
+  echo ""
+  echo -e "\t-d | --dry"
+  echo -e "\t\tPerform a dry run"
+  echo ""
+  echo -e "\t-f | --force"
+  echo -e "\t\tForce execution even if there are uncommitted changes in the workspace"
+  echo ""
+  echo -e "\t-c | --no-clean"
+  echo -e "\t\tDo not clean the workspace"
+  echo ""
+  echo -e "\t-l | --latest"
+  echo -e "\t\tApply the NPM dist-tag @latest after publish"
+  echo ""
+  echo -e "\t-t | --tag next"
+  echo -e "\t\tWhich NPM dist-tag to apply to the release. Default: next"
+
+  exit 0
+fi
+
+if [ ! -d ".git" ]; then
+  echo "Not in a git repository"
+  exit 1
+fi
+
+if changes=$(git status --porcelain) && [ -n "$changes" ] && [ -z "$FORCE" ]; then
+  echo "There are uncommitted changes in the workspace"
+  echo $changes
+  exit 1
+fi
+
+[ -n "$DRY" ] && echo "Dry run"
+
+# Ensure working directory is clean if user has not specifically disabled cleaning
+if [ -z "$NOCLEAN" ]; then
+  echo "Cleaning workspace"
+  echo "rm -rf node_modules"
+  [ -z "$DRY" ] && rm -rf node_modules
+  echo "rm -f package-lock.json"
+  [ -z "$DRY" ] && rm -f package-lock.json
+  echo "git clean -fdx"
+  [ -z "$DRY" ] && git clean -fdx
+else
+  echo "Skipping cleaning directory"
+fi
+
+echo "npm install"
+[ -z "$DRY" ] && npm install
+
+echo "npm compile"
+[ -z "$DRY" ] && npm compile
+
+echo "npm test"
+[ -z "$DRY" ] && npm test
+
+echo "npm publish --tag $TAG"
+[ -z "$DRY" ] && npm publish --tag $TAG
+
+echo "npm dist-tag add \"@opentelemetry/api@$TAG\" latest"
+if [ -n "$LATEST" ]; then
+  [ -z "$DRY" ] && npm dist-tag add "@opentelemetry/api@$TAG" latest
+fi
+
+exit 0


### PR DESCRIPTION
```shell
$ ./scripts/release.sh -h               
release.sh Usage:

ALWAYS RUN FROM THE ROOT OF THE REPOSITORY

Arguments:
        -h | --help
                Display this help message

        -d | --dry
                Perform a dry run

        -f | --force
                Force execution even if there are uncommitted changes in the workspace

        -c | --clean
                Remove all files from the workspace not tracked by git

        -l | --latest
                Apply the NPM dist-tag @latest after publish

        -t | --tag next
                Which NPM dist-tag to apply to the release. Default: next
```

```shell
$ ./scripts/release.sh -d
Dry run
Skipping cleaning directory
npm install
npm compile
npm test
npm publish --tag next
```

```shell
$ ./scripts/release.sh -d -t mytag                    
Dry run
Skipping cleaning directory
npm install
npm compile
npm test
npm publish --tag mytag
```

```shell
$ ./scripts/release.sh -d -t mytag -l 
Dry run
Skipping cleaning directory
npm install
npm compile
npm test
npm publish --tag mytag
npm dist-tag add "@opentelemetry/api@mytag" latest
```