### PR TITLE
chore: do not lint changelog

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,12 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Lint changelog file
-        uses: docker://avtodev/markdown-lint:v1
-        with:
-          config: "/lint/config/changelog.yml"
-          args: "./CHANGELOG.md"
-
       - name: Lint markdown files
         uses: docker://avtodev/markdown-lint:v1
         with:


### PR DESCRIPTION
Since the changelog is now autogenerated by release-please (example here: https://github.com/open-telemetry/opentelemetry-js-api/pull/120/files) there is no need to lint it.