### PR TITLE
feat(trace): add optional schema url to TracerProvider.getTracer

### DIFF
--- a/src/trace/ProxyTracer.ts
+++ b/src/trace/ProxyTracer.ts
@@ -19,6 +19,7 @@ import { NoopTracer } from './NoopTracer';
 import { Span } from './span';
 import { SpanOptions } from './SpanOptions';
 import { Tracer } from './tracer';
+import { TracerOptions } from './tracer_options';
 
 const NOOP_TRACER = new NoopTracer();
 
@@ -33,7 +34,7 @@ export class ProxyTracer implements Tracer {
     private _provider: TracerDelegator,
     public readonly name: string,
     public readonly version?: string,
-    public readonly schemaUrl?: string
+    public readonly options?: TracerOptions
   ) {}
 
   startSpan(name: string, options?: SpanOptions, context?: Context): Span {
@@ -59,7 +60,7 @@ export class ProxyTracer implements Tracer {
       return this._delegate;
     }
 
-    const tracer = this._provider.getDelegateTracer(this.name, this.version);
+    const tracer = this._provider.getDelegateTracer(this.name, this.version, this.options);
 
     if (!tracer) {
       return NOOP_TRACER;
@@ -71,5 +72,5 @@ export class ProxyTracer implements Tracer {
 }
 
 export interface TracerDelegator {
-  getDelegateTracer(name: string, version?: string): Tracer | undefined;
+  getDelegateTracer(name: string, version?: string, options?: TracerOptions): Tracer | undefined;
 }

--- a/src/trace/ProxyTracer.ts
+++ b/src/trace/ProxyTracer.ts
@@ -32,7 +32,8 @@ export class ProxyTracer implements Tracer {
   constructor(
     private _provider: TracerDelegator,
     public readonly name: string,
-    public readonly version?: string
+    public readonly version?: string,
+    public readonly schemaUrl?: string
   ) {}
 
   startSpan(name: string, options?: SpanOptions, context?: Context): Span {

--- a/src/trace/ProxyTracerProvider.ts
+++ b/src/trace/ProxyTracerProvider.ts
@@ -18,6 +18,7 @@ import { Tracer } from './tracer';
 import { TracerProvider } from './tracer_provider';
 import { ProxyTracer } from './ProxyTracer';
 import { NoopTracerProvider } from './NoopTracerProvider';
+import { TracerOptions } from './tracer_options';
 
 const NOOP_TRACER_PROVIDER = new NoopTracerProvider();
 
@@ -35,10 +36,10 @@ export class ProxyTracerProvider implements TracerProvider {
   /**
    * Get a {@link ProxyTracer}
    */
-  getTracer(name: string, version?: string): Tracer {
+  getTracer(name: string, version?: string, options?: TracerOptions): Tracer {
     return (
-      this.getDelegateTracer(name, version) ??
-      new ProxyTracer(this, name, version)
+      this.getDelegateTracer(name, version, options) ??
+      new ProxyTracer(this, name, version, options?.schemaUrl)
     );
   }
 
@@ -53,7 +54,11 @@ export class ProxyTracerProvider implements TracerProvider {
     this._delegate = delegate;
   }
 
-  getDelegateTracer(name: string, version?: string): Tracer | undefined {
-    return this._delegate?.getTracer(name, version);
+  getDelegateTracer(
+    name: string,
+    version?: string,
+    options?: TracerOptions
+  ): Tracer | undefined {
+    return this._delegate?.getTracer(name, version, options);
   }
 }

--- a/src/trace/ProxyTracerProvider.ts
+++ b/src/trace/ProxyTracerProvider.ts
@@ -39,7 +39,7 @@ export class ProxyTracerProvider implements TracerProvider {
   getTracer(name: string, version?: string, options?: TracerOptions): Tracer {
     return (
       this.getDelegateTracer(name, version, options) ??
-      new ProxyTracer(this, name, version, options?.schemaUrl)
+      new ProxyTracer(this, name, version, options)
     );
   }
 

--- a/src/trace/tracer_options.ts
+++ b/src/trace/tracer_options.ts
@@ -14,23 +14,12 @@
  * limitations under the License.
  */
 
-import { NoopTracer } from './NoopTracer';
-import { Tracer } from './tracer';
-import { TracerOptions } from './tracer_options';
-import { TracerProvider } from './tracer_provider';
-
 /**
- * An implementation of the {@link TracerProvider} which returns an impotent
- * Tracer for all calls to `getTracer`.
- *
- * All operations are no-op.
+ * An interface describes additional metadata of a tracer.
  */
-export class NoopTracerProvider implements TracerProvider {
-  getTracer(
-    _name?: string,
-    _version?: string,
-    _options?: TracerOptions
-  ): Tracer {
-    return new NoopTracer();
-  }
+export interface TracerOptions {
+  /**
+   * The schemaUrl of the tracer or instrumentation library
+   */
+  schemaUrl?: string;
 }

--- a/src/trace/tracer_provider.ts
+++ b/src/trace/tracer_provider.ts
@@ -30,6 +30,7 @@ export interface TracerProvider {
    *
    * @param name The name of the tracer or instrumentation library.
    * @param version The version of the tracer or instrumentation library.
+   * @param options The options of the tracer or instrumentation library.
    * @returns Tracer A Tracer with the given name and version
    */
   getTracer(name: string, version?: string, options?: TracerOptions): Tracer;

--- a/src/trace/tracer_provider.ts
+++ b/src/trace/tracer_provider.ts
@@ -15,6 +15,7 @@
  */
 
 import { Tracer } from './tracer';
+import { TracerOptions } from './tracer_options';
 
 /**
  * A registry for creating named {@link Tracer}s.
@@ -31,5 +32,5 @@ export interface TracerProvider {
    * @param version The version of the tracer or instrumentation library.
    * @returns Tracer A Tracer with the given name and version
    */
-  getTracer(name: string, version?: string): Tracer;
+  getTracer(name: string, version?: string, options?: TracerOptions): Tracer;
 }

--- a/test/noop-implementations/noop-tracer-provider.test.ts
+++ b/test/noop-implementations/noop-tracer-provider.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import { NoopTracer } from '../../src/trace/NoopTracer';
+import { NoopTracerProvider } from '../../src/trace/NoopTracerProvider';
+
+describe('NoopTracerProvider', () => {
+  it('should not crash', () => {
+    const tracerProvider = new NoopTracerProvider();
+
+    assert.ok(tracerProvider.getTracer('tracer-name') instanceof NoopTracer);
+    assert.ok(tracerProvider.getTracer('tracer-name', 'v1') instanceof NoopTracer);
+    assert.ok(tracerProvider.getTracer('tracer-name', 'v1', {
+      schemaUrl: 'https://opentelemetry.io/schemas/1.7.0'
+    }) instanceof NoopTracer);
+  });
+});

--- a/test/proxy-implementations/proxy-tracer.test.ts
+++ b/test/proxy-implementations/proxy-tracer.test.ts
@@ -81,7 +81,25 @@ describe('ProxyTracer', () => {
 
       sandbox.assert.calledOnce(getTracerStub);
       assert.strictEqual(getTracerStub.firstCall.returnValue, tracer);
-      assert.deepEqual(getTracerStub.firstCall.args, ['test', 'v0']);
+      assert.deepStrictEqual(getTracerStub.firstCall.args, [
+        'test',
+        'v0',
+        undefined,
+      ]);
+    });
+
+    it('should return tracers directly from the delegate with schema url', () => {
+      const tracer = provider.getTracer('test', 'v0', {
+        schemaUrl: 'https://opentelemetry.io/schemas/1.7.0',
+      });
+
+      sandbox.assert.calledOnce(getTracerStub);
+      assert.strictEqual(getTracerStub.firstCall.returnValue, tracer);
+      assert.deepStrictEqual(getTracerStub.firstCall.args, [
+        'test',
+        'v0',
+        { schemaUrl: 'https://opentelemetry.io/schemas/1.7.0' },
+      ]);
     });
   });
 


### PR DESCRIPTION
According to the conclusion at https://github.com/open-telemetry/opentelemetry-js/pull/2529#discussion_r737629152, the new optional parameter of `TracerProvider.getTracer` should be put into an option bag to prevent from breaking existing SDK implementations. In this way, we can also reserve the possibility for future extensions.

Fixes https://github.com/open-telemetry/opentelemetry-js-api/issues/125
Fixes https://github.com/open-telemetry/opentelemetry-js/issues/2535