### PR TITLE
Add source map files to builds

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
     "strictNullChecks": true,
     "target": "es5",
     "incremental": true,
-    "newLine": "LF"
+    "newLine": "LF",
+    "inlineSources": true
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
Related to:
- https://github.com/open-telemetry/opentelemetry-js/pull/2488
- https://github.com/open-telemetry/opentelemetry-js/issues/1887

Looking to remove all of the warnings about missing source maps