### PR TITLE
chore: update codeowners to user groups

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @dyladan @mayurkale22 @OlivierAlbertini @vmarchaud @markwolff @obecny @mwear @naseemkullah @legendecas @Flarna @johnbley @MSNev @Rauno56
+* @open-telemetry/javascript-approvers


### PR DESCRIPTION
So that we don't have to update the CODEOWNERS file every time a person joins @open-telemetry/javascript-approvers.