### PR TITLE
chore: use private token for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: GoogleCloudPlatform/release-please-action@v2
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{secrets.RELEASE_PR_TOKEN}}
           release-type: node
           package-name: "@opentelemetry/api"
       # The logic below handles the npm publication:


### PR DESCRIPTION
The token provided by default creates commits by the github action user which has not signed the CLA. Update the action to use my personal token.