### PR TITLE
feat: define common attributes type

### DIFF
--- a/src/common/Attributes.ts
+++ b/src/common/Attributes.ts
@@ -14,14 +14,22 @@
  * limitations under the License.
  */
 
-import { Attributes, AttributeValue } from '../common/Attributes';
+/**
+ * Attributes is a map from string to attribute values.
+ */
+export interface Attributes {
+    [attributeKey: string]: AttributeValue | undefined;
+}
 
 /**
- * @deprecated please use Attributes
+ * Attribute values may be any non-nullish primitive value except an object.
+ *
+ * null or undefined attribute values are invalid and will result in undefined behavior.
  */
-export type SpanAttributes = Attributes;
-
-/**
- * @deprecated please use AttributeValue
- */
-export type SpanAttributeValue = AttributeValue;
+export type AttributeValue =
+    | string
+    | number
+    | boolean
+    | Array<null | undefined | string>
+    | Array<null | undefined | number>
+    | Array<null | undefined | boolean>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export * from './baggage/types';
 export { baggageEntryMetadataFromString } from './baggage/utils';
 export * from './common/Exception';
 export * from './common/Time';
+export * from './common/Attributes';
 export * from './diag';
 export * from './propagation/TextMapPropagator';
 export * from './trace/attributes';


### PR DESCRIPTION
As discussed in SIG, this creates a common definition for attributes which can be used by all signals.

Span attributes is marked as deprecated in favor of the new common attributes definition.