### PR TITLE
fix: export tracer options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ export * from './trace/trace_state';
 export { createTraceState } from './trace/internal/utils';
 export * from './trace/tracer_provider';
 export * from './trace/tracer';
+export * from './trace/tracer_options';
 
 export {
   isSpanContextValid,


### PR DESCRIPTION
Tracer options must be exported for the type to be used externally