### PR TITLE
docs: add notes on attribute key descriptor

### DIFF
--- a/src/common/Attributes.ts
+++ b/src/common/Attributes.ts
@@ -16,6 +16,8 @@
 
 /**
  * Attributes is a map from string to attribute values.
+ *
+ * Note: only the own enumerable keys are counted as valid attribute keys.
  */
 export interface Attributes {
     [attributeKey: string]: AttributeValue | undefined;

--- a/src/trace/attributes.ts
+++ b/src/trace/attributes.ts
@@ -17,11 +17,11 @@
 import { Attributes, AttributeValue } from '../common/Attributes';
 
 /**
- * @deprecated please use Attributes
+ * @deprecated please use {@link Attributes}
  */
 export type SpanAttributes = Attributes;
 
 /**
- * @deprecated please use AttributeValue
+ * @deprecated please use {@link AttributeValue}
  */
 export type SpanAttributeValue = AttributeValue;


### PR DESCRIPTION
Currently, in https://github.com/open-telemetry/opentelemetry-js SDK implementation non-own-enumerable keys are ignored. This PR explicitly documents this behavior.

- https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-sdk-trace-base/src/Span.ts#L115
- https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-sdk-trace-base/src/Span.ts#L104
- https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-sdk-metrics-base/src/utils.ts#L30