### PR TITLE
chore: use next tag for release automation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,7 +27,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - run: npm run compile
         if: ${{ steps.release.outputs.release_created }}
-      - run: npm publish
+      - run: npm publish --tag next
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
When the API is released and there is no SDK released yet with a compatible version, the installation can fail if the user does not specifically choose the correct version and installs latest.

See https://github.com/open-telemetry/opentelemetry-js/issues/2753 for an example.