### PR TITLE
feat: Add getActiveSpan to trace API

### DIFF
--- a/src/api/trace.ts
+++ b/src/api/trace.ts
@@ -28,7 +28,7 @@ import { Tracer } from '../trace/tracer';
 import { TracerProvider } from '../trace/tracer_provider';
 import {
   deleteSpan,
-  getCurrentSpan,
+  getActiveSpan,
   getSpan,
   getSpanContext,
   setSpan,
@@ -103,7 +103,7 @@ export class TraceAPI {
 
   public getSpan = getSpan;
 
-  public getCurrentSpan = getCurrentSpan;
+  public getActiveSpan = getActiveSpan;
 
   public getSpanContext = getSpanContext;
 

--- a/src/api/trace.ts
+++ b/src/api/trace.ts
@@ -28,6 +28,7 @@ import { Tracer } from '../trace/tracer';
 import { TracerProvider } from '../trace/tracer_provider';
 import {
   deleteSpan,
+  getCurrentSpan,
   getSpan,
   getSpanContext,
   setSpan,
@@ -101,6 +102,8 @@ export class TraceAPI {
   public deleteSpan = deleteSpan;
 
   public getSpan = getSpan;
+
+  public getCurrentSpan = getCurrentSpan;
 
   public getSpanContext = getSpanContext;
 

--- a/src/trace/context-utils.ts
+++ b/src/trace/context-utils.ts
@@ -36,7 +36,7 @@ const SPAN_KEY = createContextKey('OpenTelemetry Context Key SPAN');
 }
 
 /**
- * Gets the current span from the current context, if one exists.
+ * Gets the span from the current context, if one exists.
  */
 export function getCurrentSpan(): Span | undefined {
   const ctx = ContextAPI.getInstance().active();

--- a/src/trace/context-utils.ts
+++ b/src/trace/context-utils.ts
@@ -19,7 +19,7 @@ import { Context } from '../context/types';
 import { Span } from './span';
 import { SpanContext } from './span_context';
 import { NonRecordingSpan } from './NonRecordingSpan';
-import { ContextAPI } from '../api/context';
+import { context } from '..';
 
 /**
  * span key
@@ -39,8 +39,7 @@ const SPAN_KEY = createContextKey('OpenTelemetry Context Key SPAN');
  * Gets the span from the current context, if one exists.
  */
 export function getCurrentSpan(): Span | undefined {
-  const ctx = ContextAPI.getInstance().active();
-  return getSpan(ctx);
+  return getSpan(context.active());
 }
 
 /**

--- a/src/trace/context-utils.ts
+++ b/src/trace/context-utils.ts
@@ -19,7 +19,7 @@ import { Context } from '../context/types';
 import { Span } from './span';
 import { SpanContext } from './span_context';
 import { NonRecordingSpan } from './NonRecordingSpan';
-import { context } from '..';
+import { ContextAPI } from '../api/context';
 
 /**
  * span key
@@ -39,7 +39,7 @@ export function getSpan(context: Context): Span | undefined {
  * Gets the span from the current context, if one exists.
  */
 export function getCurrentSpan(): Span | undefined {
-  return getSpan(context.active());
+  return getSpan(ContextAPI.getInstance().active());
 }
 
 /**

--- a/src/trace/context-utils.ts
+++ b/src/trace/context-utils.ts
@@ -19,6 +19,7 @@ import { Context } from '../context/types';
 import { Span } from './span';
 import { SpanContext } from './span_context';
 import { NonRecordingSpan } from './NonRecordingSpan';
+import { ContextAPI } from '../api/context';
 
 /**
  * span key
@@ -26,12 +27,21 @@ import { NonRecordingSpan } from './NonRecordingSpan';
 const SPAN_KEY = createContextKey('OpenTelemetry Context Key SPAN');
 
 /**
- * Return the span if one exists
+ * Gets the span from the given context, if it exists. If no context is specified,
+ * attempts to get the curent span from the current context, if it exists.
  *
- * @param context context to get span from
+ * @param context context to get span from. If unspecified, the currently active context is used.
  */
-export function getSpan(context: Context): Span | undefined {
+export function getSpan(context: Context = ContextAPI.getInstance().active()): Span | undefined {
   return (context.getValue(SPAN_KEY) as Span) || undefined;
+}
+
+/**
+ * Gets the current span from the current context, if one exists.
+ */
+export function getCurrentSpan(): Span | undefined {
+  const ctx = ContextAPI.getInstance().active();
+  return getSpan(ctx);
 }
 
 /**

--- a/src/trace/context-utils.ts
+++ b/src/trace/context-utils.ts
@@ -31,7 +31,7 @@ const SPAN_KEY = createContextKey('OpenTelemetry Context Key SPAN');
  *
  * @param context context to get span from
  */
- export function getSpan(context: Context): Span | undefined {
+export function getSpan(context: Context): Span | undefined {
   return (context.getValue(SPAN_KEY) as Span) || undefined;
 }
 

--- a/src/trace/context-utils.ts
+++ b/src/trace/context-utils.ts
@@ -27,12 +27,11 @@ import { ContextAPI } from '../api/context';
 const SPAN_KEY = createContextKey('OpenTelemetry Context Key SPAN');
 
 /**
- * Gets the span from the given context, if it exists. If no context is specified,
- * attempts to get the curent span from the current context, if it exists.
+ * Return the span if one exists
  *
- * @param context context to get span from. If unspecified, the currently active context is used.
+ * @param context context to get span from
  */
-export function getSpan(context: Context = ContextAPI.getInstance().active()): Span | undefined {
+ export function getSpan(context: Context): Span | undefined {
   return (context.getValue(SPAN_KEY) as Span) || undefined;
 }
 

--- a/src/trace/context-utils.ts
+++ b/src/trace/context-utils.ts
@@ -38,7 +38,7 @@ export function getSpan(context: Context): Span | undefined {
 /**
  * Gets the span from the current context, if one exists.
  */
-export function getCurrentSpan(): Span | undefined {
+export function getActiveSpan(): Span | undefined {
   return getSpan(ContextAPI.getInstance().active());
 }
 

--- a/test/api/api.test.ts
+++ b/test/api/api.test.ts
@@ -35,6 +35,7 @@ import { DiagAPI } from '../../src/api/diag';
 import { NonRecordingSpan } from '../../src/trace/NonRecordingSpan';
 import { NoopTracer } from '../../src/trace/NoopTracer';
 import { NoopTracerProvider } from '../../src/trace/NoopTracerProvider';
+import { ContextManager } from '../../src';
 
 // DiagLogger implementation
 const diagLoggerFunctions = [
@@ -50,7 +51,15 @@ describe('API', () => {
     const tracer = api.trace.getTracerProvider();
     assert.ok(tracer);
     assert.strictEqual(typeof tracer, 'object');
-  });
+  }),
+  it('getCurrentspan should get the current span', () => {
+    const span = new NonRecordingSpan();
+    const ctx = trace.setSpan(ROOT_CONTEXT, span);
+    context.setGlobalContextManager({ active: () => ctx } as any as ContextManager);
+    
+    const active = trace.getCurrentSpan();
+    assert.strictEqual(active, span);
+  }),
 
   describe('Context', () => {
     it('with should forward this, arguments and return value', () => {

--- a/test/api/api.test.ts
+++ b/test/api/api.test.ts
@@ -35,7 +35,6 @@ import { DiagAPI } from '../../src/api/diag';
 import { NonRecordingSpan } from '../../src/trace/NonRecordingSpan';
 import { NoopTracer } from '../../src/trace/NoopTracer';
 import { NoopTracerProvider } from '../../src/trace/NoopTracerProvider';
-import { ContextManager } from '../../src';
 
 // DiagLogger implementation
 const diagLoggerFunctions = [
@@ -51,15 +50,18 @@ describe('API', () => {
     const tracer = api.trace.getTracerProvider();
     assert.ok(tracer);
     assert.strictEqual(typeof tracer, 'object');
-  }),
-  it('getCurrentspan should get the current span', () => {
+  });
+
+  it('getCurrentSpan should get the current span', () => {
     const span = new NonRecordingSpan();
     const ctx = trace.setSpan(ROOT_CONTEXT, span);
-    context.setGlobalContextManager({ active: () => ctx } as any as ContextManager);
+    context.setGlobalContextManager({ active: () => ctx, disable: () => {} } as any);
     
     const active = trace.getCurrentSpan();
     assert.strictEqual(active, span);
-  }),
+
+    context.disable();
+  });
 
   describe('Context', () => {
     it('with should forward this, arguments and return value', () => {

--- a/test/api/api.test.ts
+++ b/test/api/api.test.ts
@@ -52,12 +52,12 @@ describe('API', () => {
     assert.strictEqual(typeof tracer, 'object');
   });
 
-  it('getCurrentSpan should get the current span', () => {
+  it('getActiveSpan should get the current span', () => {
     const span = new NonRecordingSpan();
     const ctx = trace.setSpan(ROOT_CONTEXT, span);
     context.setGlobalContextManager({ active: () => ctx, disable: () => {} } as any);
     
-    const active = trace.getCurrentSpan();
+    const active = trace.getActiveSpan();
     assert.strictEqual(active, span);
 
     context.disable();


### PR DESCRIPTION
Based on discussion in https://github.com/open-telemetry/opentelemetry-js-api/issues/162 I'm opening this up. Both approached discussed in the issue are present -- it'd be great to get to consensus on if we want to do this, and if so, which approach to take.

My preference would be to have the additional `getActiveSpan` function, but it'd be great to hear what others think.

N.B. the implementations here may be suboptimal; this is mostly just to aid discussion