### PR TITLE
feat: deprecate Sampler

### DIFF
--- a/src/trace/Sampler.ts
+++ b/src/trace/Sampler.ts
@@ -21,6 +21,7 @@ import { SamplingResult } from './SamplingResult';
 import { SpanKind } from './span_kind';
 
 /**
+ * @deprecated use the one declared in @opentelemetry/sdk-trace-base instead.
  * This interface represent a sampler. Sampling is a mechanism to control the
  * noise and overhead introduced by OpenTelemetry by reducing the number of
  * samples of traces collected and sent to the backend.

--- a/src/trace/SamplingResult.ts
+++ b/src/trace/SamplingResult.ts
@@ -17,6 +17,7 @@
 import { SpanAttributes } from './attributes';
 
 /**
+ * @deprecated use the one declared in @opentelemetry/sdk-trace-base instead.
  * A sampling decision that determines how a {@link Span} will be recorded
  * and collected.
  */
@@ -39,6 +40,7 @@ export enum SamplingDecision {
 }
 
 /**
+ * @deprecated use the one declared in @opentelemetry/sdk-trace-base instead.
  * A sampling result contains a decision for a {@link Span} and additional
  * attributes the sampler would like to added to the Span.
  */


### PR DESCRIPTION
Preferring the one declared in @opentelemetry/sdk-trace-base.

Fixes: https://github.com/open-telemetry/opentelemetry-js-api/issues/148
Related: https://github.com/open-telemetry/opentelemetry-js/pull/3088