### PR TITLE
feat(TraceProvider): add shutdown and forceFlush to API

### DIFF
--- a/src/trace/NoopTracerProvider.ts
+++ b/src/trace/NoopTracerProvider.ts
@@ -33,4 +33,12 @@ export class NoopTracerProvider implements TracerProvider {
   ): Tracer {
     return new NoopTracer();
   }
+
+  shutdown(): Promise<void> {
+    return Promise.resolve(undefined);
+  }
+
+  forceFlush(): Promise<void> {
+    return Promise.resolve(undefined);
+  }
 }

--- a/src/trace/ProxyTracerProvider.ts
+++ b/src/trace/ProxyTracerProvider.ts
@@ -61,4 +61,12 @@ export class ProxyTracerProvider implements TracerProvider {
   ): Tracer | undefined {
     return this._delegate?.getTracer(name, version, options);
   }
+
+  shutdown(): Promise<void> {
+    return this.getDelegate().shutdown()
+  }
+
+  forceFlush(): Promise<void> {
+    return this.getDelegate().forceFlush();
+  }
 }

--- a/src/trace/tracer_provider.ts
+++ b/src/trace/tracer_provider.ts
@@ -34,4 +34,14 @@ export interface TracerProvider {
    * @returns Tracer A Tracer with the given name and version
    */
   getTracer(name: string, version?: string, options?: TracerOptions): Tracer;
+
+  /**
+   * Shutdown all internal processors and blocks until all data is flushed
+   */
+  shutdown(): Promise<void>;
+
+  /**
+   * Flushes all data hold in span processors to the configured exporters
+   */
+  forceFlush(): Promise<void>
 }

--- a/test/proxy-implementations/proxy-tracer.test.ts
+++ b/test/proxy-implementations/proxy-tracer.test.ts
@@ -34,6 +34,10 @@ describe('ProxyTracer', () => {
   let provider: ProxyTracerProvider;
   const sandbox = sinon.createSandbox();
 
+  const voidPromiseResolve = (): Promise<void> => {
+    return Promise.resolve()
+  }
+
   beforeEach(() => {
     provider = new ProxyTracerProvider();
   });
@@ -72,6 +76,8 @@ describe('ProxyTracer', () => {
       getTracerStub = sandbox.stub().returns(new NoopTracer());
       delegate = {
         getTracer: getTracerStub,
+        forceFlush: voidPromiseResolve,
+        shutdown: voidPromiseResolve,
       };
       provider.setDelegate(delegate);
     });
@@ -127,6 +133,8 @@ describe('ProxyTracer', () => {
         getTracer() {
           return delegateTracer;
         },
+        forceFlush: voidPromiseResolve,
+        shutdown: voidPromiseResolve,
       };
       provider.setDelegate(delegate);
     });


### PR DESCRIPTION
This PR exposes the `shutdown` and `forcedFlush` functions defined by the [TraceProvider specs](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#shutdown). 

Providing these methods allow to gracefully shutdown instrumentations without data loss. Currently this is only possible with usage of the SDK specific implementations [see](https://github.com/open-telemetry/opentelemetry-js/issues/3310)
## Context
Closes https://github.com/open-telemetry/opentelemetry-js/issues/3310