### PR TITLE
feat: never return undefined when the method expects an object

### DIFF
--- a/src/baggage/context-helpers.ts
+++ b/src/baggage/context-helpers.ts
@@ -17,6 +17,7 @@
 import { createContextKey } from '../context/context';
 import { Context } from '../context/types';
 import { Baggage } from './types';
+import { createBaggage } from './utils';
 
 /**
  * Baggage key
@@ -29,8 +30,8 @@ const BAGGAGE_KEY = createContextKey('OpenTelemetry Baggage Key');
  * @param {Context} Context that manage all context values
  * @returns {Baggage} Extracted baggage from the context
  */
-export function getBaggage(context: Context): Baggage | undefined {
-  return (context.getValue(BAGGAGE_KEY) as Baggage) || undefined;
+export function getBaggage(context: Context): Baggage {
+  return (context.getValue(BAGGAGE_KEY) as Baggage) || createBaggage();
 }
 
 /**

--- a/src/baggage/internal/baggage-impl.ts
+++ b/src/baggage/internal/baggage-impl.ts
@@ -23,10 +23,10 @@ export class BaggageImpl implements Baggage {
     this._entries = entries ? new Map(entries) : new Map();
   }
 
-  getEntry(key: string): BaggageEntry | undefined {
+  getEntry(key: string): BaggageEntry {
     const entry = this._entries.get(key);
     if (!entry) {
-      return undefined;
+      return { value: '' };
     }
 
     return Object.assign({}, entry);

--- a/src/baggage/types.ts
+++ b/src/baggage/types.ts
@@ -61,7 +61,7 @@ export interface Baggage {
    *
    * @param key The key which identifies the BaggageEntry
    */
-  getEntry(key: string): BaggageEntry | undefined;
+  getEntry(key: string): BaggageEntry;
 
   /**
    * Get a list of all entries in the Baggage

--- a/src/trace/context-utils.ts
+++ b/src/trace/context-utils.ts
@@ -31,14 +31,14 @@ const SPAN_KEY = createContextKey('OpenTelemetry Context Key SPAN');
  *
  * @param context context to get span from
  */
-export function getSpan(context: Context): Span | undefined {
+export function getSpan(context: Context): Span {
   return (context.getValue(SPAN_KEY) as Span) || new NonRecordingSpan();
 }
 
 /**
  * Gets the span from the current context, if one exists.
  */
-export function getActiveSpan(): Span | undefined {
+export function getActiveSpan(): Span {
   return getSpan(ContextAPI.getInstance().active());
 }
 

--- a/src/trace/context-utils.ts
+++ b/src/trace/context-utils.ts
@@ -80,6 +80,6 @@ export function setSpanContext(
  *
  * @param context context to get values from
  */
-export function getSpanContext(context: Context): SpanContext | undefined {
-  return getSpan(context)?.spanContext();
+export function getSpanContext(context: Context): SpanContext {
+  return getSpan(context).spanContext();
 }

--- a/src/trace/context-utils.ts
+++ b/src/trace/context-utils.ts
@@ -32,7 +32,7 @@ const SPAN_KEY = createContextKey('OpenTelemetry Context Key SPAN');
  * @param context context to get span from
  */
 export function getSpan(context: Context): Span | undefined {
-  return (context.getValue(SPAN_KEY) as Span) || undefined;
+  return (context.getValue(SPAN_KEY) as Span) || new NonRecordingSpan();
 }
 
 /**

--- a/test/api/api.test.ts
+++ b/test/api/api.test.ts
@@ -35,6 +35,7 @@ import { DiagAPI } from '../../src/api/diag';
 import { NonRecordingSpan } from '../../src/trace/NonRecordingSpan';
 import { NoopTracer } from '../../src/trace/NoopTracer';
 import { NoopTracerProvider } from '../../src/trace/NoopTracerProvider';
+import { INVALID_SPAN_CONTEXT } from '../../src/trace/invalid-span-constants';
 
 // DiagLogger implementation
 const diagLoggerFunctions = [
@@ -56,11 +57,23 @@ describe('API', () => {
     const span = new NonRecordingSpan();
     const ctx = trace.setSpan(ROOT_CONTEXT, span);
     context.setGlobalContextManager({ active: () => ctx, disable: () => {} } as any);
-    
+
     const active = trace.getActiveSpan();
     assert.strictEqual(active, span);
 
     context.disable();
+  });
+
+  it('setSpanContext and getSpanContext should set and get span context', () => {
+    const tracer = api.trace.getTracerProvider().getTracer('name');
+    const span = tracer.startSpan('test');
+    let ctx = ROOT_CONTEXT;
+
+    assert.equal(INVALID_SPAN_CONTEXT, span.spanContext());
+    assert.equal(INVALID_SPAN_CONTEXT, trace.getSpanContext(ctx));
+
+    ctx = trace.setSpanContext(ctx, span.spanContext());
+    assert.strictEqual(span.spanContext(), trace.getSpanContext(ctx));
   });
 
   describe('Context', () => {

--- a/test/baggage/Baggage.test.ts
+++ b/test/baggage/Baggage.test.ts
@@ -140,6 +140,11 @@ describe('Baggage', () => {
 
       assert.strictEqual(bag, propagation.getBaggage(ctx));
     });
+
+    it('should get an empty baggage if none is in the context', () => {
+      const bag = propagation.getBaggage(ROOT_CONTEXT);
+      assert.deepEqual(propagation.createBaggage(), bag);
+    });
   });
 
   describe('metadata', () => {

--- a/test/baggage/Baggage.test.ts
+++ b/test/baggage/Baggage.test.ts
@@ -55,6 +55,15 @@ describe('Baggage', () => {
 
       assert.strictEqual(bag.getEntry('key')?.value, 'value');
     });
+
+    it('should return an invalid entry if none exists', () => {
+      const bag = propagation
+        .createBaggage();
+
+      const entry = bag.getEntry('key');
+      assert.ok(entry);
+      assert.equal(entry.value, '');
+    });
   });
 
   describe('set', () => {

--- a/test/trace/context-utils.test.ts
+++ b/test/trace/context-utils.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import * as context from '../../src/trace/context-utils';
+import { NonRecordingSpan } from '../../src/trace/NonRecordingSpan';
+import { ROOT_CONTEXT, TraceFlags } from '../../src';
+
+describe('context-utils', () => {
+  const spanContext = {
+    traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+    spanId: '6e0c63257de34c92',
+    traceFlags: TraceFlags.NONE,
+  };
+  const dummySpan = new NonRecordingSpan(spanContext);
+
+  it('should return the current span', () => {
+    const ctx = context.setSpan(ROOT_CONTEXT, dummySpan);
+    assert.strictEqual(context.getSpan(ctx), dummySpan);
+  });
+
+  it('should default to a non-recording span', () => {
+    const ctx = ROOT_CONTEXT;
+    assert.deepEqual(context.getSpan(ctx), new NonRecordingSpan());
+  });
+});


### PR DESCRIPTION
I believe returning `undefined` when the context has no span is invalid per the specification:

https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/error-handling.md#guidance

> Whenever API call returns values that is expected to be non-null value - in case of error in processing logic - SDK MUST return a "no-op" or any other "default" object that was (ideally) pre-allocated and readily available. This way API call sites will not crash on attempts to access methods and properties of a null objects.

See also the discussion in https://github.com/open-telemetry/oteps/issues/216

Note: this may be deemed a breaking change, in which case I am happy to rename the commit to `feat`, and to wait for the next planned appropriate release.